### PR TITLE
fix(release): runtime Vitest config & TypeDoc fixes

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -46,6 +46,7 @@
 		"typedoc": "typedoc --options ./typedoc.json"
 	},
 	"devDependencies": {
+		"@testing-library/react": "^16.3.1",
 		"@vitest/coverage-v8": "^4.0.18",
 		"typedoc": "^0.28.16"
 	}

--- a/packages/react/src/primitives/tooltip/src/lib/useTooltip.ts
+++ b/packages/react/src/primitives/tooltip/src/lib/useTooltip.ts
@@ -1,5 +1,5 @@
 import { autoUpdate, useFloating, type Placement } from "@floating-ui/react";
-import { useMemo, useRef } from "react";
+import { useMemo, useRef, type RefObject } from "react";
 
 import type { TooltipOptions } from "./types";
 import { normalizeTooltipOptions } from "./defaults";
@@ -8,7 +8,34 @@ import { useRuntimeOptions } from "./useRuntimeOptions";
 import { buildTooltipMiddleware } from "./middleware";
 import { useTooltipInteractions } from "./interactions";
 
-export function useTooltip(options?: TooltipOptions) {
+// Explicit return type to avoid TypeDoc / TS inferring types that reference
+// non-portable types from @floating-ui packages (TS2742). We declare the
+// commonly-used fields concretely and keep the rest loose.
+export type UseTooltipReturn = {
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  arrowRef: RefObject<SVGSVGElement | null>;
+  setOptions: (opts: Record<string, unknown>) => void;
+
+  // Floating-ui helpers used by components
+  getReferenceProps: (props?: Record<string, unknown>) => Record<string, unknown>;
+  getFloatingProps: (props?: Record<string, unknown>) => Record<string, unknown>;
+  refs: {
+    reference: { current: unknown | null };
+    setReference: (node: unknown) => void;
+    setFloating: (node: unknown) => void;
+  };
+
+  // layout / position
+  placement?: string;
+  isPositioned?: boolean;
+  floatingStyles?: any;
+
+  // internal floating context (kept as any for portability)
+  context?: any;
+} & Record<string, unknown>;
+
+export function useTooltip(options?: TooltipOptions): UseTooltipReturn {
   const o = normalizeTooltipOptions(options);
 
   const { open, setOpen, isControlled } = useControllableOpen({
@@ -63,5 +90,5 @@ export function useTooltip(options?: TooltipOptions) {
       ...data, // includes isPositioned
     }),
     [open, setOpen, interactions, data, setOptions]
-  );
+  ) as UseTooltipReturn;
 }

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -6,5 +6,12 @@
   ],
   "entryPointStrategy": "expand",
   "tsconfig": "tsconfig.json",
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**"
+  ],
   "out": "docs"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -456,6 +456,9 @@ importers:
         specifier: ^3.20.0
         version: 3.21.0
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.1
+        version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)


### PR DESCRIPTION
Added JS Vitest runtime config and updated package export to avoid Node ESM loading .ts at runtime; excluded test files from TypeDoc and added a portable return type for the tooltip hook to avoid non-portable @floating-ui types during docs generation. This fixes CI failures during the release workflow (typedoc & vitest).