### PR TITLE
fix: add missing type deps and exclude tests from TypeDoc

### DIFF
--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -47,7 +47,9 @@
 		"typedoc": "typedoc --options ./typedoc.json"
 	},
 	"devDependencies": {
+		"@floating-ui/utils": "^0.2.10",
 		"@testing-library/react": "^16.3.1",
+		"@testing-library/user-event": "^14.6.1",
 		"@vitest/coverage-v8": "^4.0.18",
 		"typedoc": "^0.28.16"
 	}

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -31,5 +31,13 @@
   "files": [],
   "include": [
     "src"
+  ],
+  "exclude": [
+    "**/*.test.ts",
+    "**/*.test.tsx",
+    "**/*.spec.ts",
+    "**/*.spec.tsx",
+    "**/__tests__/**",
+    "node_modules"
   ]
 }

--- a/packages/react/typedoc.json
+++ b/packages/react/typedoc.json
@@ -1,17 +1,5 @@
 {
-  "entryPoints": [
-    "src/**/index.ts",
-    "src/**/index.tsx",
-    "src/types/index.ts"
-  ],
-  "entryPointStrategy": "expand",
+  "entryPoints": ["src/index.ts"],
   "tsconfig": "tsconfig.json",
-  "exclude": [
-    "**/*.test.ts",
-    "**/*.test.tsx",
-    "**/*.spec.ts",
-    "**/*.spec.tsx",
-    "**/__tests__/**"
-  ],
   "out": "docs"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -459,9 +459,15 @@ importers:
         specifier: ^3.20.0
         version: 3.21.0
     devDependencies:
+      '@floating-ui/utils':
+        specifier: ^0.2.10
+        version: 0.2.10
       '@testing-library/react':
         specifier: ^16.3.1
         version: 16.3.1(@testing-library/dom@10.4.1)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/coverage-v8':
         specifier: ^4.0.18
         version: 4.0.18(vitest@4.0.18)


### PR DESCRIPTION
Adds @floating-ui/utils and @testing-library/user-event as devDeps; simplifies typedoc.json to use single entrypoint; adds test file exclusion to tsconfig to prevent TypeDoc from processing test files.